### PR TITLE
docs: rename features to tasks in universal verification RFC

### DIFF
--- a/docs/RFC-UNIVERSAL-VERIFICATION-STRATEGY.md
+++ b/docs/RFC-UNIVERSAL-VERIFICATION-STRATEGY.md
@@ -1,4 +1,4 @@
-# RFC: Universal Verification Strategy System
+# RFC: Universal Task Verification Strategy System
 
 > Status: **Proposed** | Priority: **High** | Created: 2025-12-04
 
@@ -6,11 +6,36 @@
 
 Transform agent-foreman from a code-centric testing tool into a **universal task framework** with pluggable verification strategies. This enables verification of any type of task - coding, operations, data pipelines, infrastructure, and non-technical work (marketing, content creation, etc.).
 
+### Key Terminology Change
+
+| Old Term | New Term | Rationale |
+|----------|----------|-----------|
+| `features` | `tasks` | "Feature" implies software; "Task" is universal |
+| `ai/features/` | `ai/tasks/` | Directory rename |
+| `feature_list.json` | `task_list.json` | File rename |
+| `Feature` interface | `Task` interface | Type rename |
+| `featureId` | `taskId` | Parameter rename |
+
+This change enables agent-foreman to handle:
+- Software features (coding tasks)
+- Operations automation (ops tasks)
+- Marketing campaigns (manual tasks)
+- Data processing (data tasks)
+- Infrastructure provisioning (infra tasks)
+
 ## Problem Statement
 
-The current verification system has significant limitations:
+The current system has significant limitations:
 
-### 1. Testing-Centric Design
+### 1. Feature-Centric Naming
+
+The current naming (`features`, `feature_list.json`, `ai/features/`) implies this tool is only for software feature development. This creates cognitive friction when using it for:
+- Operations tasks (backups, deployments, monitoring)
+- Marketing tasks (campaigns, content, social media)
+- Data tasks (ETL, reports, analysis)
+- Administrative tasks (documentation, reviews)
+
+### 2. Testing-Centric Verification
 
 The `testRequirements` field only supports two verification types:
 
@@ -22,14 +47,14 @@ interface TestRequirements {
 ```
 
 This excludes:
-- API endpoint verification (curl/httpie checks)
-- Database state verification (SQL queries)
-- File output verification (check generated files)
-- External service verification (did the tweet post?)
-- Manual verification (human review required)
-- Custom script verification (shell scripts)
+- Script execution verification
+- HTTP/API endpoint verification
+- File output verification
+- External service verification
+- Manual/human verification
+- Custom command verification
 
-### 2. Code-Centric Capability Detection
+### 3. Code-Centric Capability Detection
 
 The capability detection system looks for development files:
 - `package.json`, `Cargo.toml`, `pom.xml`, etc.
@@ -41,13 +66,6 @@ This fails for:
 - Ansible/Terraform infrastructure projects
 - Marketing automation tasks
 
-### 3. Verification Assumes Code Changes
-
-The diff-based verification expects git changes:
-- Operations tasks may not change code at all
-- May execute external actions (post to social media, run migrations)
-- Need verification of **outcomes**, not code
-
 ### 4. No Composite Verification
 
 Cannot combine multiple verification methods:
@@ -56,21 +74,140 @@ Cannot combine multiple verification methods:
 
 ## Proposed Solution
 
-Introduce a **pluggable verification strategy system** that supports multiple verification methods per feature while maintaining full backward compatibility.
+### 1. Rename Features to Tasks
+
+Complete terminology migration throughout the codebase:
+
+```
+ai/features/           → ai/tasks/
+ai/features/index.json → ai/tasks/index.json
+feature_list.json      → task_list.json (legacy, still supported)
+Feature interface      → Task interface
+FeatureStatus          → TaskStatus
+FeatureIndex           → TaskIndex
+```
+
+### 2. Pluggable Verification Strategies
+
+Introduce `verificationStrategies` array supporting multiple verification methods per task.
 
 ### Design Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Strategy storage | `verificationStrategies[]` array on Feature | Multiple strategies per feature, explicit ordering |
-| Backward compatibility | Runtime auto-conversion of `testRequirements` | Zero migration required for existing projects |
-| Default behavior | AI verification when no strategies defined | Maintains current behavior for existing features |
-| Composite logic | AND/OR with nested strategies | Supports complex verification requirements |
-| Execution model | Sequential with early-exit on failure (AND) | Predictable, debuggable behavior |
+| Primary term | `Task` (not Feature) | Universal applicability |
+| Strategy storage | `verificationStrategies[]` on Task | Multiple strategies per task |
+| Backward compatibility | Runtime alias: `Feature` = `Task` | Zero breaking changes |
+| Composite logic | AND/OR with nested strategies | Complex verification needs |
+| Default behavior | AI verification when no strategies | Maintains current behavior |
 
 ## Technical Design
 
-### New Type Definitions
+### Task Type Definitions
+
+Rename and extend in `src/types.ts`:
+
+```typescript
+// ============================================================================
+// Task Types (formerly Feature Types)
+// ============================================================================
+
+/**
+ * Task status values
+ * - failing: Not yet completed
+ * - passing: Acceptance criteria met
+ * - blocked: External dependency blocking progress
+ * - needs_review: Potentially affected by recent changes
+ * - deprecated: No longer needed
+ */
+export type TaskStatus =
+  | "failing"
+  | "passing"
+  | "blocked"
+  | "needs_review"
+  | "deprecated";
+
+/**
+ * How the task was created/discovered
+ */
+export type TaskOrigin =
+  | "init-auto"
+  | "init-from-routes"
+  | "init-from-tests"
+  | "manual"
+  | "replan";
+
+/**
+ * Task type hint for appropriate verification defaults
+ */
+export type TaskType = "code" | "ops" | "data" | "infra" | "manual";
+
+/**
+ * Single task entry
+ * Renamed from Feature for universal applicability
+ */
+export interface Task {
+  /** Unique identifier, e.g., "auth.login" or "ops.backup.daily" */
+  id: string;
+  /** Human-readable description */
+  description: string;
+  /** Parent module/category */
+  module: string;
+  /** Priority (1 = highest) */
+  priority: number;
+  /** Current status */
+  status: TaskStatus;
+  /** List of acceptance criteria */
+  acceptance: string[];
+  /** Task IDs this task depends on */
+  dependsOn: string[];
+  /** Task IDs this task replaces */
+  supersedes: string[];
+  /** Categorization tags */
+  tags: string[];
+  /** Increments when description changes */
+  version: number;
+  /** How this task was created */
+  origin: TaskOrigin;
+  /** Additional context or notes */
+  notes: string;
+  /** Last verification result */
+  verification?: TaskVerificationSummary;
+
+  /**
+   * Task type hint for appropriate verification defaults
+   * - code: Software development tasks (default for backward compat)
+   * - ops: Operations/automation tasks
+   * - data: Data processing/pipeline tasks
+   * - infra: Infrastructure/DevOps tasks
+   * - manual: Tasks requiring human action
+   */
+  taskType?: TaskType;
+
+  /**
+   * Verification strategies for this task
+   * When defined, replaces testRequirements and AI default
+   */
+  verificationStrategies?: VerificationStrategy[];
+
+  // Legacy fields (backward compatibility)
+  /** @deprecated Use verificationStrategies */
+  testRequirements?: TestRequirements;
+  /** E2E test tags (legacy, use verificationStrategies) */
+  e2eTags?: string[];
+  /** Test files (legacy) */
+  testFiles?: string[];
+  /** TDD guidance cache (legacy) */
+  tddGuidance?: CachedTDDGuidance;
+}
+
+// Backward compatibility alias
+export type Feature = Task;
+export type FeatureStatus = TaskStatus;
+export type FeatureOrigin = TaskOrigin;
+```
+
+### Verification Strategy Types
 
 Add to `src/verification-types.ts`:
 
@@ -79,189 +216,109 @@ Add to `src/verification-types.ts`:
 // Verification Strategy Types
 // ============================================================================
 
-/**
- * Verification strategy type identifiers
- */
 export type VerificationStrategyType =
-  | "test"      // Unit/integration tests (existing behavior)
-  | "e2e"       // End-to-end tests (existing behavior)
-  | "script"    // Custom shell script verification
+  | "test"      // Unit/integration tests
+  | "e2e"       // End-to-end tests
+  | "script"    // Custom shell script
   | "http"      // HTTP endpoint verification
-  | "file"      // File existence/content verification
-  | "command"   // Command execution with expected output
-  | "manual"    // Human review required
+  | "file"      // File existence/content
+  | "command"   // Command execution
+  | "manual"    // Human review
   | "ai"        // AI-powered verification
-  | "composite"; // Combination of multiple strategies
+  | "composite"; // Combination of strategies
 
-/**
- * Base interface for all verification strategies
- */
 export interface BaseVerificationStrategy {
-  /** Strategy type discriminator */
   type: VerificationStrategyType;
-  /** Human-readable description */
   description?: string;
-  /** Whether this strategy must pass for verification to succeed */
   required: boolean;
-  /** Timeout in milliseconds (default: 60000) */
-  timeout?: number;
-  /** Retry count on failure (default: 0) */
-  retries?: number;
-  /** Environment variables for execution */
+  timeout?: number;      // ms, default: 60000
+  retries?: number;      // default: 0
   env?: Record<string, string>;
 }
 
-/**
- * Test-based verification
- * Backward compatible with testRequirements.unit
- */
+// Test verification (backward compat with testRequirements.unit)
 export interface TestVerificationStrategy extends BaseVerificationStrategy {
   type: "test";
-  /** Glob pattern for test files */
   pattern?: string;
-  /** Test framework (auto-detected if not specified) */
   framework?: string;
-  /** Expected test case names */
   cases?: string[];
-  /** Tags for filtering */
   tags?: string[];
 }
 
-/**
- * E2E test verification
- * Backward compatible with testRequirements.e2e
- */
+// E2E verification (backward compat with testRequirements.e2e)
 export interface E2EVerificationStrategy extends BaseVerificationStrategy {
   type: "e2e";
-  /** Glob pattern for E2E test files */
   pattern?: string;
-  /** E2E framework (playwright, cypress, puppeteer) */
   framework?: string;
-  /** Tags for filtering (@smoke, @auth, etc.) */
   tags?: string[];
-  /** Expected scenario names */
   scenarios?: string[];
 }
 
-/**
- * Custom script verification
- * For shell scripts that verify task completion
- */
+// Script verification
 export interface ScriptVerificationStrategy extends BaseVerificationStrategy {
   type: "script";
-  /** Path to script (relative to project root) */
-  script: string;
-  /** Arguments to pass to script */
+  script: string;              // Path to script
   args?: string[];
-  /** Expected exit code (default: 0) */
-  expectedExitCode?: number;
-  /** Regex pattern that stdout must match */
-  outputPattern?: string;
+  expectedExitCode?: number;   // default: 0
+  outputPattern?: string;      // Regex for stdout
 }
 
-/**
- * HTTP endpoint verification
- * For API health checks and response validation
- */
+// HTTP verification
 export interface HttpVerificationStrategy extends BaseVerificationStrategy {
   type: "http";
-  /** HTTP method */
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
-  /** URL (supports ${ENV_VAR} substitution) */
-  url: string;
-  /** Expected HTTP status code(s) */
+  url: string;                 // Supports ${ENV_VAR}
   expectedStatus: number | number[];
-  /** Request headers */
   headers?: Record<string, string>;
-  /** Request body (for POST/PUT/PATCH) */
   body?: string | Record<string, unknown>;
-  /** Regex pattern for response body */
   responsePattern?: string;
-  /** JSON path assertions for response */
-  jsonAssertions?: Array<{
-    path: string;
-    expected: unknown;
-  }>;
+  jsonAssertions?: Array<{ path: string; expected: unknown; }>;
 }
 
-/**
- * File verification
- * For checking generated files, outputs, artifacts
- */
+// File verification
 export interface FileVerificationStrategy extends BaseVerificationStrategy {
   type: "file";
-  /** File paths to check (glob patterns supported) */
   paths: string[];
-  /** Checks to perform on each file */
   checks: Array<{
     type: "exists" | "not-exists" | "contains" | "matches" | "size" | "permissions";
     value?: string | number;
   }>;
 }
 
-/**
- * Command verification
- * For arbitrary command execution with output validation
- */
+// Command verification
 export interface CommandVerificationStrategy extends BaseVerificationStrategy {
   type: "command";
-  /** Command to execute */
   command: string;
-  /** Working directory (default: project root) */
   cwd?: string;
-  /** Expected exit code (default: 0) */
   expectedExitCode?: number | number[];
-  /** Regex pattern for stdout */
   stdoutPattern?: string;
-  /** Regex pattern for stderr */
   stderrPattern?: string;
-  /** Patterns that should NOT appear in output (fail if found) */
   notPatterns?: string[];
 }
 
-/**
- * Manual verification
- * For human review with guided checklist
- */
+// Manual verification
 export interface ManualVerificationStrategy extends BaseVerificationStrategy {
   type: "manual";
-  /** Instructions for the reviewer */
   instructions: string;
-  /** Checklist items to verify */
   checklist?: string[];
-  /** Assigned reviewer (optional) */
   assignee?: string;
 }
 
-/**
- * AI-powered verification
- * Uses AI to analyze artifacts and determine completion
- */
+// AI verification
 export interface AIVerificationStrategy extends BaseVerificationStrategy {
   type: "ai";
-  /** AI verification mode */
   mode?: "diff" | "autonomous";
-  /** Custom prompt for AI analysis */
   customPrompt?: string;
-  /** Minimum confidence threshold (0-1) */
   minConfidence?: number;
 }
 
-/**
- * Composite verification
- * Combines multiple strategies with AND/OR logic
- */
+// Composite verification (AND/OR logic)
 export interface CompositeVerificationStrategy extends BaseVerificationStrategy {
   type: "composite";
-  /** Logical operator for combining results */
   logic: "and" | "or";
-  /** Child strategies to execute */
   strategies: VerificationStrategy[];
 }
 
-/**
- * Union type of all verification strategies
- */
 export type VerificationStrategy =
   | TestVerificationStrategy
   | E2EVerificationStrategy
@@ -274,162 +331,50 @@ export type VerificationStrategy =
   | CompositeVerificationStrategy;
 ```
 
-### Feature Interface Extension
+### Directory Structure Migration
 
-Add to `src/types.ts`:
-
-```typescript
-/**
- * Task type hint for appropriate verification defaults
- */
-export type TaskType = "code" | "ops" | "data" | "infra" | "manual";
-
-export interface Feature {
-  // ... existing fields ...
-
-  /**
-   * DEPRECATED: Use verificationStrategies instead
-   * Kept for backward compatibility - auto-converted at runtime
-   */
-  testRequirements?: TestRequirements;
-
-  /**
-   * Verification strategies for this feature (NEW)
-   * When defined, replaces testRequirements and AI default
-   */
-  verificationStrategies?: VerificationStrategy[];
-
-  /**
-   * Task type hint for appropriate verification defaults
-   */
-  taskType?: TaskType;
-}
 ```
-
-### Strategy Executor Framework
-
-New file `src/strategy-executor.ts`:
-
-```typescript
-export interface StrategyExecutionResult {
-  /** Strategy that was executed */
-  strategy: VerificationStrategy;
-  /** Whether execution succeeded */
-  success: boolean;
-  /** Command/script output */
-  output?: string;
-  /** Error message if failed */
-  error?: string;
-  /** Execution duration in milliseconds */
-  duration: number;
-  /** Strategy-specific details */
-  details?: Record<string, unknown>;
-}
-
-export interface ExecutionContext {
-  /** Project root directory */
-  cwd: string;
-  /** Feature being verified */
-  feature: Feature;
-  /** Detected project capabilities */
-  capabilities: ExtendedCapabilities;
-  /** Verbose output mode */
-  verbose?: boolean;
-}
-
-export interface StrategyExecutor<T extends VerificationStrategy> {
-  /** Execute the verification strategy */
-  execute(strategy: T, context: ExecutionContext): Promise<StrategyExecutionResult>;
-  /** Validate strategy configuration */
-  validate(strategy: T): { valid: boolean; errors: string[] };
-}
-
-export class StrategyExecutorRegistry {
-  private executors = new Map<VerificationStrategyType, StrategyExecutor<any>>();
-
-  register<T extends VerificationStrategy>(
-    type: T["type"],
-    executor: StrategyExecutor<T>
-  ): void {
-    this.executors.set(type, executor);
-  }
-
-  async execute(
-    strategy: VerificationStrategy,
-    context: ExecutionContext
-  ): Promise<StrategyExecutionResult> {
-    const executor = this.executors.get(strategy.type);
-    if (!executor) {
-      throw new Error(`No executor registered for strategy type: ${strategy.type}`);
-    }
-    return executor.execute(strategy, context);
-  }
-}
+Before:                          After:
+ai/                              ai/
+├── features/                    ├── tasks/              (renamed)
+│   ├── index.json              │   ├── index.json
+│   ├── auth/                   │   ├── auth/           (code tasks)
+│   │   └── login.md            │   │   └── login.md
+│   └── chat/                   │   ├── ops/            (ops tasks)
+│       └── message.edit.md     │   │   └── backup.daily.md
+├── feature_list.json (legacy)  │   ├── marketing/      (manual tasks)
+└── progress.log                │   │   └── twitter.campaign.md
+                                │   └── data/           (data tasks)
+                                │       └── etl.customers.md
+                                ├── task_list.json      (legacy alias)
+                                ├── feature_list.json   (legacy, auto-migrated)
+                                └── progress.log
 ```
 
 ### Strategy Resolution Logic
 
-Add to `src/verifier.ts`:
-
 ```typescript
-/**
- * Determine verification strategies for a feature
- * Priority:
- * 1. feature.verificationStrategies (if defined)
- * 2. Convert feature.testRequirements (if defined) - BACKWARD COMPAT
- * 3. Default based on feature.taskType
- * 4. AI verification (ultimate fallback)
- */
-export function getVerificationStrategies(feature: Feature): VerificationStrategy[] {
-  // 1. Use explicit strategies if defined
-  if (feature.verificationStrategies?.length > 0) {
-    return feature.verificationStrategies;
+export function getVerificationStrategies(task: Task): VerificationStrategy[] {
+  // 1. Explicit strategies
+  if (task.verificationStrategies?.length > 0) {
+    return task.verificationStrategies;
   }
 
-  // 2. Convert legacy testRequirements (full backward compatibility)
-  if (feature.testRequirements) {
-    return convertTestRequirementsToStrategies(feature.testRequirements);
+  // 2. Convert legacy testRequirements
+  if (task.testRequirements) {
+    return convertTestRequirementsToStrategies(task.testRequirements);
   }
 
-  // 3. Use taskType defaults
-  if (feature.taskType) {
-    return getDefaultStrategiesForTaskType(feature.taskType);
+  // 3. TaskType defaults
+  if (task.taskType) {
+    return getDefaultStrategiesForTaskType(task.taskType);
   }
 
-  // 4. Default to AI verification
+  // 4. Default to AI
   return [{ type: "ai", required: true, mode: "autonomous" }];
 }
 
-function convertTestRequirementsToStrategies(
-  requirements: TestRequirements
-): VerificationStrategy[] {
-  const strategies: VerificationStrategy[] = [];
-
-  if (requirements.unit) {
-    strategies.push({
-      type: "test",
-      required: requirements.unit.required,
-      pattern: requirements.unit.pattern,
-      cases: requirements.unit.cases,
-    });
-  }
-
-  if (requirements.e2e) {
-    strategies.push({
-      type: "e2e",
-      required: requirements.e2e.required,
-      pattern: requirements.e2e.pattern,
-      tags: requirements.e2e.tags,
-      scenarios: requirements.e2e.scenarios,
-    });
-  }
-
-  return strategies;
-}
-
-function getDefaultStrategiesForTaskType(
-  taskType: TaskType
-): VerificationStrategy[] {
+function getDefaultStrategiesForTaskType(taskType: TaskType): VerificationStrategy[] {
   switch (taskType) {
     case "code":
       return [
@@ -439,7 +384,7 @@ function getDefaultStrategiesForTaskType(
     case "ops":
       return [
         { type: "script", required: false, script: "./verify.sh" },
-        { type: "ai", required: true, mode: "autonomous" }
+        { type: "ai", required: true }
       ];
     case "data":
       return [
@@ -453,101 +398,237 @@ function getDefaultStrategiesForTaskType(
       ];
     case "manual":
       return [{ type: "manual", required: true, instructions: "" }];
-    default:
-      return [{ type: "ai", required: true }];
   }
 }
 ```
 
 ## Implementation Plan
 
-### Phase 1: Type System Extension
+### Phase 1: Type System Rename + Extension
 
 **Files:**
-- `src/verification-types.ts` - Add all strategy type definitions
-- `src/types.ts` - Add `verificationStrategies`, `taskType` to Feature
+- `src/types.ts` - Rename Feature → Task, add aliases
+- `src/verification-types.ts` - Add strategy type definitions
 
-**Estimated changes:** ~300 lines
+**Changes:**
+- Add `Task` interface (copy of Feature with new fields)
+- Add `TaskStatus`, `TaskOrigin`, `TaskType`
+- Export `Feature` as alias: `export type Feature = Task`
+- Add `verificationStrategies` and `taskType` fields
 
-### Phase 2: Strategy Executor Framework
+### Phase 2: Storage Layer Migration
 
 **Files:**
-- `src/strategy-executor.ts` (NEW) - Executor framework and registry
+- `src/feature-storage.ts` → `src/task-storage.ts`
+- `src/feature-list.ts` → `src/task-list.ts`
 
-**Estimated changes:** ~150 lines
+**Changes:**
+- Support both `ai/features/` and `ai/tasks/` directories
+- Auto-migrate `ai/features/` to `ai/tasks/` on first access
+- Support `feature_list.json` and `task_list.json` (legacy)
 
-### Phase 3: Individual Strategy Executors
+### Phase 3: Strategy Executor Framework
 
-**New directory: `src/strategies/`**
-
-| File | Priority | Description |
-|------|----------|-------------|
-| `index.ts` | High | Registry and exports |
-| `test-executor.ts` | High | Unit test (refactor existing) |
-| `e2e-executor.ts` | High | E2E test (refactor existing) |
-| `script-executor.ts` | High | Custom shell scripts |
-| `command-executor.ts` | High | Command with expected output |
-| `ai-executor.ts` | High | AI verification (refactor existing) |
-| `http-executor.ts` | High | HTTP endpoint verification |
-| `manual-executor.ts` | High | Manual checklist prompts |
-| `file-executor.ts` | Medium | File existence/content checks |
-| `composite-executor.ts` | High | AND/OR composite logic |
-
-**Estimated changes:** ~800 lines total
+**New files:**
+- `src/strategy-executor.ts` - Executor framework
+- `src/strategies/index.ts` - Registry
+- `src/strategies/*.ts` - Individual executors
 
 ### Phase 4: Verifier Integration
 
+**File:** `src/verifier.ts`
+
+**Changes:**
+- Integrate strategy executor framework
+- Add `getVerificationStrategies()`
+- Support composite AND/OR logic
+
+### Phase 5: CLI Updates
+
+**File:** `src/index.ts`
+
+**Changes:**
+- Update help text (feature → task)
+- Add `--task-type` flag for init
+- Update progress log format
+
+### Phase 6: Documentation
+
 **Files:**
-- `src/verifier.ts` - Integrate strategy executor framework
-
-**Estimated changes:** ~200 lines
-
-### Phase 5: Schema Updates
-
-**Files:**
-- `src/schema.ts` - Add JSON Schema for new fields
-
-**Estimated changes:** ~150 lines
-
-### Phase 6: Feature Storage Updates
-
-**Files:**
-- `src/feature-storage.ts` - Serialize/parse strategies in YAML frontmatter
-
-**Estimated changes:** ~50 lines
+- `CLAUDE.md` - Update terminology
+- `README.md` - Update examples
+- `docs/USAGE.md` - Update guides
 
 ## Example Configurations
 
-### 1. Frontend Coding (Unchanged - Backward Compatible)
-
-Existing `testRequirements` continues to work:
+### 1. Code Task (Software Feature)
 
 ```yaml
+---
 id: auth.login
-testRequirements:
-  unit:
-    required: true
-    pattern: "tests/auth/**/*.test.ts"
-  e2e:
-    required: false
-    tags: ["@auth"]
+module: auth
+taskType: code
+priority: 1
+status: failing
+---
+# User Authentication Login
+
+## Acceptance Criteria
+
+1. User can login with email/password
+2. Invalid credentials show error
+3. Session persists across refreshes
 ```
 
-### 2. Backend API Development
+### 2. Ops Task (Database Backup)
 
 ```yaml
+---
+id: ops.backup.daily
+module: ops
+taskType: ops
+priority: 1
+status: failing
+verificationStrategies:
+  - type: composite
+    logic: and
+    required: true
+    strategies:
+      - type: script
+        script: "./scripts/verify-backup.sh"
+        timeout: 300000
+      - type: file
+        paths: ["/backups/db-*.sql.gz"]
+        checks:
+          - type: exists
+          - type: size
+            value: 1000000
+---
+# Daily Database Backup
+
+## Acceptance Criteria
+
+1. Backup file created in /backups/
+2. Backup file > 1MB (not empty)
+3. Backup can be restored successfully
+```
+
+### 3. Marketing Task (Twitter Campaign)
+
+```yaml
+---
+id: marketing.twitter.product_launch
+module: marketing
+taskType: manual
+priority: 2
+status: failing
+verificationStrategies:
+  - type: manual
+    required: true
+    instructions: |
+      Verify the product launch tweet:
+      1. Posted to @company account
+      2. Includes product image
+      3. Has correct hashtags
+      4. Link works with UTM tracking
+    checklist:
+      - "Tweet is live"
+      - "Image displays correctly"
+      - "#ProductLaunch #2025 hashtags present"
+      - "UTM link tracks correctly"
+    assignee: "marketing-team"
+---
+# Product Launch Twitter Campaign
+
+## Acceptance Criteria
+
+1. Tweet posted at scheduled time
+2. Engagement > 100 interactions in 24h
+3. Link click-through rate > 2%
+```
+
+### 4. Data Task (ETL Pipeline)
+
+```yaml
+---
+id: data.etl.customer_sync
+module: data
+taskType: data
+priority: 1
+status: failing
+verificationStrategies:
+  - type: composite
+    logic: and
+    required: true
+    strategies:
+      - type: command
+        command: "python -m pytest tests/etl/ -v"
+      - type: file
+        paths: ["output/customers_*.csv"]
+        checks:
+          - type: exists
+          - type: contains
+            value: "customer_id,name,email"
+---
+# Customer Data ETL Sync
+
+## Acceptance Criteria
+
+1. All customer records synced from source
+2. Output CSV has correct schema
+3. No duplicate records
+4. Sync completes in < 30 minutes
+```
+
+### 5. Infrastructure Task (Terraform)
+
+```yaml
+---
+id: infra.aws.vpc_setup
+module: infra
+taskType: infra
+priority: 1
+status: failing
+verificationStrategies:
+  - type: composite
+    logic: and
+    required: true
+    strategies:
+      - type: command
+        command: "terraform validate"
+        cwd: "infrastructure/aws"
+      - type: command
+        command: "terraform plan -detailed-exitcode"
+        cwd: "infrastructure/aws"
+        expectedExitCode: [0, 2]
+---
+# AWS VPC Infrastructure Setup
+
+## Acceptance Criteria
+
+1. VPC created with correct CIDR
+2. Public/private subnets configured
+3. NAT Gateway operational
+4. Security groups properly configured
+```
+
+### 6. Backend API Task
+
+```yaml
+---
 id: api.users.create
+module: api
 taskType: code
+priority: 1
+status: failing
 verificationStrategies:
   - type: composite
     logic: and
     required: true
     strategies:
       - type: test
-        required: true
         pattern: "tests/api/users/**/*.test.ts"
       - type: http
-        required: true
         method: POST
         url: "http://localhost:3000/api/users"
         body:
@@ -557,121 +638,62 @@ verificationStrategies:
         jsonAssertions:
           - path: "$.id"
             expected: { "type": "string" }
+---
+# Create User API Endpoint
+
+## Acceptance Criteria
+
+1. POST /api/users creates user
+2. Returns 201 with user object
+3. Validates required fields
+4. Handles duplicate email gracefully
 ```
 
-### 3. Operations Task (Database Backup)
+## Migration Strategy
 
-```yaml
-id: ops.backup_database
-taskType: ops
-verificationStrategies:
-  - type: composite
-    logic: and
-    required: true
-    strategies:
-      - type: script
-        required: true
-        script: "./scripts/verify-backup.sh"
-        timeout: 300000
-      - type: file
-        required: true
-        paths: ["/backups/db-*.sql.gz"]
-        checks:
-          - type: exists
-          - type: size
-            value: 1000000
+### Automatic Backward Compatibility
+
+1. **Type aliases**: `Feature = Task`, `FeatureStatus = TaskStatus`
+2. **Directory support**: Both `ai/features/` and `ai/tasks/` work
+3. **File support**: Both `feature_list.json` and `task_list.json` work
+4. **testRequirements**: Auto-converted to verificationStrategies at runtime
+
+### Migration Command
+
+```bash
+# Preview migration
+agent-foreman migrate --dry-run
+
+# Execute migration
+agent-foreman migrate
+
+# Force re-migration
+agent-foreman migrate --force
 ```
 
-### 4. Marketing Task (Social Media Post)
+### CLI Aliases
 
-```yaml
-id: marketing.twitter_campaign
-taskType: manual
-verificationStrategies:
-  - type: manual
-    required: true
-    instructions: |
-      Verify the following for the Twitter campaign:
-      1. Tweet was posted to @company account
-      2. Image/media is correctly attached
-      3. All hashtags are present and correct
-      4. Link is working and tracking correctly
-    checklist:
-      - "Tweet is live on @company account"
-      - "Image displays correctly"
-      - "Hashtags: #launch #product #2025"
-      - "UTM tracking link works"
-    assignee: "marketing-team"
-```
-
-### 5. Data Pipeline Task
-
-```yaml
-id: data.etl.customer_sync
-taskType: data
-verificationStrategies:
-  - type: composite
-    logic: and
-    required: true
-    strategies:
-      - type: command
-        required: true
-        command: "python -m pytest tests/etl/ -v"
-      - type: file
-        required: true
-        paths: ["output/customers_*.csv"]
-        checks:
-          - type: exists
-          - type: contains
-            value: "customer_id,name,email"
-```
-
-### 6. Infrastructure Task (Terraform)
-
-```yaml
-id: infra.aws.vpc_setup
-taskType: infra
-verificationStrategies:
-  - type: composite
-    logic: and
-    required: true
-    strategies:
-      - type: command
-        required: true
-        command: "terraform validate"
-        cwd: "infrastructure/aws"
-      - type: command
-        required: true
-        command: "terraform plan -detailed-exitcode"
-        cwd: "infrastructure/aws"
-        expectedExitCode: [0, 2]
-      - type: command
-        required: false
-        command: "tflint"
-        cwd: "infrastructure/aws"
+```bash
+# These all work:
+agent-foreman next              # Next task
+agent-foreman done <taskId>     # Complete task
+agent-foreman done <featureId>  # Still works (alias)
 ```
 
 ## Security Considerations
 
 ### 1. Command Injection Prevention
 
-All command strings must be sanitized before execution:
-
 ```typescript
-// Use existing isPathWithinRoot() pattern
 function sanitizeCommand(command: string, cwd: string): string {
-  // Validate command doesn't escape project root
-  // Escape shell metacharacters
-  // Block dangerous patterns
+  // Validate no shell metacharacters escape
+  // Block dangerous patterns (rm -rf, etc.)
 }
 ```
 
 ### 2. Path Traversal Prevention
 
-File paths in `FileVerificationStrategy` must be validated:
-
 ```typescript
-// Validate all paths stay within project root
 function validateFilePaths(paths: string[], cwd: string): boolean {
   return paths.every(p => isPathWithinRoot(p, cwd));
 }
@@ -679,76 +701,47 @@ function validateFilePaths(paths: string[], cwd: string): boolean {
 
 ### 3. HTTP SSRF Prevention
 
-URL validation for `HttpVerificationStrategy`:
-
 ```typescript
-// Only allow localhost/internal URLs or explicit allowlist
-function validateUrl(url: string, allowedHosts: string[]): boolean {
-  const parsed = new URL(url);
-  return allowedHosts.includes(parsed.hostname);
+function validateUrl(url: string): boolean {
+  // Only allow localhost or configured hosts
+  const allowedHosts = ["localhost", "127.0.0.1", ...config.allowedHosts];
 }
 ```
 
 ### 4. Environment Variable Safety
 
-Never log sensitive environment variables:
-
 ```typescript
-const SENSITIVE_PATTERNS = [/password/i, /secret/i, /token/i, /key/i];
-
-function redactSensitiveEnv(env: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(env).map(([k, v]) =>
-      SENSITIVE_PATTERNS.some(p => p.test(k)) ? [k, "***REDACTED***"] : [k, v]
-    )
-  );
-}
+const SENSITIVE_PATTERNS = [/password/i, /secret/i, /token/i, /key/i, /api_key/i];
+// Redact in logs, never expose
 ```
 
 ## Testing Strategy
 
 ### Unit Tests
-
-1. **Strategy executors**: Each executor tested in isolation with mocked dependencies
-2. **Composite logic**: AND/OR combinations with various success/failure patterns
-3. **Backward compatibility**: `testRequirements` to `verificationStrategies` conversion
+- Each strategy executor
+- Composite AND/OR logic
+- testRequirements conversion
+- Task/Feature type compatibility
 
 ### Integration Tests
-
-1. **Full verification flow**: Feature with multiple strategies
-2. **Timeout handling**: Strategies that exceed timeout
-3. **Retry logic**: Failed strategies with retry configuration
+- Full verification flow
+- Directory migration
+- CLI commands with new terminology
 
 ### E2E Tests
-
-1. **CLI integration**: `agent-foreman done` with new strategy types
-2. **Manual verification**: Interactive prompt flow (skip in CI)
-
-## Migration Path
-
-### Automatic Backward Compatibility
-
-1. **Existing `testRequirements`** - Automatically converted to `verificationStrategies` via `convertTestRequirementsToStrategies()` at runtime
-2. **No `testRequirements` or `verificationStrategies`** - Defaults to AI verification (current behavior)
-3. **Existing TDD mode features** - Continue to work because conversion preserves `required: true`
-
-### No Breaking Changes
-
-The implementation ensures:
-- Existing features with `testRequirements` continue to work unchanged
-- Existing `e2eTags` field continues to work
-- `determineVerificationMode()` continues to work for legacy features
-- All existing CLI commands work without modification
+- `agent-foreman done` with all strategy types
+- Manual verification prompt flow
 
 ## Future Considerations
 
-1. **Database verification strategy** - Direct SQL query assertions
-2. **Cloud resource verification** - AWS/GCP/Azure resource state checks
-3. **Webhook verification** - Wait for webhook callback
-4. **Approval workflow** - Multi-person approval chains
-5. **Custom strategy plugins** - User-defined strategy types
-6. **Strategy templates** - Reusable strategy configurations
+1. **Task templates** - Predefined task types with verification presets
+2. **Task workflows** - Multi-stage tasks with dependencies
+3. **Approval chains** - Multi-person manual verification
+4. **Webhooks** - Wait for external callback
+5. **Database verification** - Direct SQL assertions
+6. **Cloud resource checks** - AWS/GCP/Azure state verification
+7. **Custom strategy plugins** - User-defined executors
 
 ---
 
-*This RFC documents a proposed enhancement to agent-foreman for universal task verification.*
+*This RFC documents a proposed enhancement to transform agent-foreman into a universal task framework.*


### PR DESCRIPTION
This RFC proposes transforming agent-foreman into a universal task framework with pluggable verification strategies.

Key changes:
- Rename Feature → Task throughout codebase
- Rename ai/features/ → ai/tasks/ directory
- Add taskType field (code, ops, data, infra, manual)
- Add verificationStrategies array with 9 strategy types
- Full backward compatibility with type aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)